### PR TITLE
Handle MQTT client logout errors and retry login

### DIFF
--- a/src/accessories/climate.ts
+++ b/src/accessories/climate.ts
@@ -184,11 +184,12 @@ export default class ClimateAccessory extends JciHitachiAccessory{
       const buttonCleanSwitch = '凍結洗淨';
 
       this.services['CleanSwitch'] = this.accessory.getServiceById(this.platform.Service.Switch, ClimateCommandType.CleanSwitch) || this.accessory.addService(this.platform.Service.Switch,  buttonCleanSwitch, ClimateCommandType.CleanSwitch);
-          
+
       this.services['CleanSwitch'].setCharacteristic(this.platform.Characteristic.Name, buttonCleanSwitch);
       this.services['CleanSwitch'].getCharacteristic(this.platform.Characteristic.On)
         .onSet(this.setCleanSwitch.bind(this))
         .onGet(this.getCleanSwitch.bind(this));
+      this.services['CleanSwitch'].updateCharacteristic(this.platform.Characteristic.On, false);
           
       this.services['CleanSwitch'].addOptionalCharacteristic(this.platform.Characteristic.ConfiguredName);
       this.services['CleanSwitch'].setCharacteristic(this.platform.Characteristic.ConfiguredName, buttonCleanSwitch);
@@ -198,22 +199,24 @@ export default class ClimateAccessory extends JciHitachiAccessory{
     }
 
 
+    ///////////
 
-    ///////////    
+    this.services['LeakSensor'] = this.accessory.getService(this.platform.Service.LeakSensor)
+      || this.accessory.addService(this.platform.Service.LeakSensor, '凍結洗淨通知');
+
+    this.services['LeakSensor'].setCharacteristic(this.platform.Characteristic.Name, '凍結洗淨通知');
+    this.services['LeakSensor'].getCharacteristic(this.platform.Characteristic.LeakDetected)
+      .onGet(this.getCleanNotification.bind(this));
+    this.services['LeakSensor'].updateCharacteristic(
+      this.platform.Characteristic.LeakDetected,
+      this.platform.Characteristic.LeakDetected.LEAK_NOT_DETECTED,
+    );
+
+    this.services['LeakSensor'].addOptionalCharacteristic(this.platform.Characteristic.ConfiguredName);
+    this.services['LeakSensor'].setCharacteristic(this.platform.Characteristic.ConfiguredName, '凍結洗淨通知');
 
 
-     this.services['LeakSensor'] = this.accessory.getService(this.platform.Service.LeakSensor) || this.accessory.addService(this.platform.Service.LeakSensor, '凍結洗淨通知');
-    
-     this.services['LeakSensor'].setCharacteristic(this.platform.Characteristic.Name, '凍結洗淨通知');
-     this.services['LeakSensor'].getCharacteristic(this.platform.Characteristic.LeakDetected)
-    .onGet(this.getCleanNotification.bind(this));
 
-     this.services['LeakSensor'].addOptionalCharacteristic(this.platform.Characteristic.ConfiguredName);
-     this.services['LeakSensor'].setCharacteristic(this.platform.Characteristic.ConfiguredName, '凍結洗淨通知');
-
-
-
-    
     this.refreshDeviceStatus();
 
   }
@@ -286,20 +289,22 @@ export default class ClimateAccessory extends JciHitachiAccessory{
   }
 
   async setCleanSwitch(value: CharacteristicValue) {
-    
+
     this.platform.log.debug(`Accessory: setCleanSwitch() for device '${this.accessory.displayName}' to ${value}}`);
 
     this.setStatus(ClimateCommandType.CleanSwitch, value ? 1 : 0);
-    this.services['CleanSwitch'].updateCharacteristic(this.platform.Characteristic.On, value);
-   
+    this.services['CleanSwitch'].updateCharacteristic(this.platform.Characteristic.On, !!value);
+
   }
-  
+
   async getCleanSwitch():Promise<CharacteristicValue> {
-    return this.accessory.context.device.CleanSwitch;
+    return !!this.accessory.context.device.CleanSwitch;
   }
 
   async getCleanNotification():Promise<CharacteristicValue> {
-    return this.accessory.context.device.CleanNotification;
+    return this.accessory.context.device.CleanNotification
+      ? this.platform.Characteristic.LeakDetected.LEAK_DETECTED
+      : this.platform.Characteristic.LeakDetected.LEAK_NOT_DETECTED;
   }
     
 
@@ -542,14 +547,26 @@ export default class ClimateAccessory extends JciHitachiAccessory{
 
     this.services['AirQualitySensor'].updateCharacteristic(
       this.platform.Characteristic.StatusActive,
-      this.accessory.context.device.SwitchOn || 0,
+      !!this.accessory.context.device.SwitchOn,
     );
 
 
     if(this.platform.jciHitachiAWSAPI.isHost){
-             
-      this.services['QuickMode'].updateCharacteristic(this.platform.Characteristic.On, this.accessory.context.device.QuickMode || 0);
-      this.services['CleanSwitch'].updateCharacteristic(this.platform.Characteristic.On, this.accessory.context.device.CleanSwitch || 0);
+
+      this.services['QuickMode'].updateCharacteristic(
+        this.platform.Characteristic.On,
+        !!this.accessory.context.device.QuickMode,
+      );
+      this.services['CleanSwitch'].updateCharacteristic(
+        this.platform.Characteristic.On,
+        !!this.accessory.context.device.CleanSwitch,
+      );
+      this.services['LeakSensor'].updateCharacteristic(
+        this.platform.Characteristic.LeakDetected,
+        this.accessory.context.device.CleanNotification
+          ? this.platform.Characteristic.LeakDetected.LEAK_DETECTED
+          : this.platform.Characteristic.LeakDetected.LEAK_NOT_DETECTED,
+      );
 
     }
 

--- a/src/jci-hitachi-aws-api.ts
+++ b/src/jci-hitachi-aws-api.ts
@@ -636,7 +636,8 @@ export default class JciHitachiAWSAPI {
 
 
         }catch(e){
-            this.log.error(`Login Error: ${e}`);            
+            this.isLoginFailed = true;
+            this.log.error(`Login Error: ${e}`);
         }
     
 
@@ -860,6 +861,7 @@ export default class JciHitachiAWSAPI {
             this.log.debug("Connack: " + JSON.stringify(eventData.connack));
             this.log.debug("Settings: " + JSON.stringify(eventData.settings));
             this.isConnected = true;
+            this.isLoginFailed = false;
 
         });
 

--- a/src/jci-hitachi-aws-api.ts
+++ b/src/jci-hitachi-aws-api.ts
@@ -708,15 +708,14 @@ export default class JciHitachiAWSAPI {
     public async RefeshDevice(thingName:string): Promise<boolean> {
 
         if(this.last_received_time != 0 && Math.ceil(Date.now() / 1000) - this.last_received_time > 600){
-            
-            this.log.error('MQTT Connection Timeout');
-                                    
-            await this.Logout();
-            
-            this.log.info('Re-Login');
-            await this.Login();
-            
-            
+            if(this.isConnected){
+                this.log.error('MQTT Connection Timeout');
+                this.isConnected = false;
+                this.isLoginFailed = true;
+                if(this.callback){
+                    this.callback(undefined);
+                }
+            }
             return false;
         }
 

--- a/src/jci-hitachi-aws-api.ts
+++ b/src/jci-hitachi-aws-api.ts
@@ -869,7 +869,14 @@ export default class JciHitachiAWSAPI {
             this.log.error("Connection failure event: " + eventData.error.toString());
             this.isConnected = false;
             this.isLoginFailed = true;
-            //throw new Error("Connection failure event: " + eventData.error.toString());
+
+            const failingClient = this.mqttclient;
+            this.mqttclient = undefined;
+            try {
+                failingClient?.stop();
+            } catch {
+                // ignore stop errors
+            }
 
             if(this.callback){
                 this.callback(undefined);

--- a/src/jci-hitachi-aws-api.ts
+++ b/src/jci-hitachi-aws-api.ts
@@ -650,37 +650,33 @@ export default class JciHitachiAWSAPI {
 
             this.isConnected = false;
 
-            if(this.mqttclient){
+            const client = this.mqttclient;
+            this.mqttclient = undefined;
 
-                const unsuback = await this.mqttclient.unsubscribe({
+            if(client){
+
+                const unsuback = await client.unsubscribe({
                     topicFilters: [
                         `${this.aws_identity?.host_identity_id}/#`
                     ]
                 });
                 this.log.debug('Unsuback result: ' + JSON.stringify(unsuback));
-            
-                const disconnection = once(this.mqttclient, "disconnection");
-                const stopped = once(this.mqttclient, "stopped");
-    
-                this.mqttclient.stop();
-    
+
+                const disconnection = once(client, "disconnection").catch(() => {});
+                const stopped = once(client, "stopped").catch(() => {});
+
+                client.stop();
+
                 await disconnection;
                 await stopped;
 
-                this.mqttclient = undefined;
-            
             }
 
             return true;
         }catch(e){
-            this.mqttclient = undefined;
             this.log.error(`Logout Error: ${e}`);
+            return false;
         }
-
-
-
-
-        return true;
     }
 
     public get isHost(): boolean {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -36,7 +36,8 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
   // Used to track restored cached accessories
   private readonly accessories: PlatformAccessory<JciHitachiAccessoryContext>[] = [];
 
-  private _loginRetryTimeout: NodeJS.Timer | undefined;
+  private _loginRetryTimeout: NodeJS.Timeout | undefined;
+  private _isLoggingIn = false;
   private noOfFailedLoginAttempts = 0;
 
   public jciHitachiAWSAPI: JciHitachiAWSAPI;
@@ -87,7 +88,12 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
   protected notifyCallback (thing: AWSThings|undefined){
 
     if(this.jciHitachiAWSAPI.isConnected == false){
-      
+      if (this._isLoggingIn) {
+        return;
+      }
+      if (this._loginRetryTimeout) {
+        clearTimeout(this._loginRetryTimeout);
+      }
       this._loginRetryTimeout = setTimeout(
         this.loginAndDiscoverDevices.bind(this),
         LOGIN_RETRY_DELAY,
@@ -119,6 +125,15 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
   }
 
   async loginAndDiscoverDevices() {
+    if (this._isLoggingIn || this.jciHitachiAWSAPI.isConnected) {
+      return;
+    }
+
+    if (this._loginRetryTimeout) {
+      clearTimeout(this._loginRetryTimeout);
+      this._loginRetryTimeout = undefined;
+    }
+
     if (!this.platformConfig.email) {
       this.log.error('Email is not configured - aborting plugin start. '
         + 'Please set the field `email` in your config and restart Homebridge.');
@@ -131,7 +146,10 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    if(this.jciHitachiAWSAPI === undefined || this.jciHitachiAWSAPI.isLoginFailed == true){
+    this._isLoggingIn = true;
+
+    try {
+      if(this.jciHitachiAWSAPI === undefined || this.jciHitachiAWSAPI.isLoginFailed == true){
 
         this.log.info('Creating New JciHitachiAWSAPI.');
 
@@ -141,27 +159,26 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
           this.platformConfig.password,
           this.log
         );
-        
+
         this.jciHitachiAWSAPI.setCallback(this.notifyCallback.bind(this));
-    }
+      }
 
+      this.log.info('Attempting to log into JciHitachiAWSAPI.');
+      await this.jciHitachiAWSAPI.Login();
 
-    this.log.info('Attempting to log into JciHitachiAWSAPI.');
-    this.jciHitachiAWSAPI.Login()
-      .then(() => {
-        if(this.jciHitachiAWSAPI.isConnected){
-          this.log.info('Successfully logged in.');
-          this.noOfFailedLoginAttempts = 0;
-          this.discoverDevices();
-        }
-        else{
-          this.handleLoginFailure();
-        }
-
-      })
-      .catch(() => {
+      if(this.jciHitachiAWSAPI.isConnected){
+        this.log.info('Successfully logged in.');
+        this.noOfFailedLoginAttempts = 0;
+        this.discoverDevices();
+      }
+      else{
         this.handleLoginFailure();
-      });
+      }
+    } catch {
+      this.handleLoginFailure();
+    } finally {
+      this._isLoggingIn = false;
+    }
   }
 
   private handleLoginFailure() {
@@ -177,6 +194,9 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
         + 'Restart Homebridge when you change your config.',
       );
 
+      if (this._loginRetryTimeout) {
+        clearTimeout(this._loginRetryTimeout);
+      }
       this._loginRetryTimeout = setTimeout(
         this.loginAndDiscoverDevices.bind(this),
         LOGIN_RETRY_DELAY,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -155,36 +155,39 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
           this.discoverDevices();
         }
         else{
-          this.log.error('Login failed. Skipping device discovery.');
-          this.noOfFailedLoginAttempts++;
+          this.handleLoginFailure();
         }
 
       })
       .catch(() => {
-        this.log.error('Login failed. Skipping device discovery.');
-        this.noOfFailedLoginAttempts++;
-
-        if (this.noOfFailedLoginAttempts < MAX_NO_OF_FAILED_LOGIN_ATTEMPTS) {
-          this.log.error(
-            'The JciHitachiAWSAPI server might be experiencing issues at the moment. '
-            + `The plugin will try to log in again in ${LOGIN_RETRY_DELAY / 1000} seconds. `
-            + 'If the issue persists, make sure you configured the correct email and password '
-            + 'and run the latest version of the plugin. '
-            + 'Restart Homebridge when you change your config.',
-          );
-
-          this._loginRetryTimeout = setTimeout(
-            this.loginAndDiscoverDevices.bind(this),
-            LOGIN_RETRY_DELAY,
-          );
-        } else {
-          this.log.error(
-            'Maximum number of failed login attempts reached '
-            + `(${MAX_NO_OF_FAILED_LOGIN_ATTEMPTS}). `
-            + 'Check your login details and restart Homebridge to reset the plugin.',
-          );
-        }
+        this.handleLoginFailure();
       });
+  }
+
+  private handleLoginFailure() {
+    this.log.error('Login failed. Skipping device discovery.');
+    this.noOfFailedLoginAttempts++;
+
+    if (this.noOfFailedLoginAttempts < MAX_NO_OF_FAILED_LOGIN_ATTEMPTS) {
+      this.log.error(
+        'The JciHitachiAWSAPI server might be experiencing issues at the moment. '
+        + `The plugin will try to log in again in ${LOGIN_RETRY_DELAY / 1000} seconds. `
+        + 'If the issue persists, make sure you configured the correct email and password '
+        + 'and run the latest version of the plugin. '
+        + 'Restart Homebridge when you change your config.',
+      );
+
+      this._loginRetryTimeout = setTimeout(
+        this.loginAndDiscoverDevices.bind(this),
+        LOGIN_RETRY_DELAY,
+      );
+    } else {
+      this.log.error(
+        'Maximum number of failed login attempts reached '
+        + `(${MAX_NO_OF_FAILED_LOGIN_ATTEMPTS}). `
+        + 'Check your login details and restart Homebridge to reset the plugin.',
+      );
+    }
   }
 
   /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -149,7 +149,10 @@ export default class JciHitachiPlatform implements DynamicPlatformPlugin {
     this._isLoggingIn = true;
 
     try {
-      if(this.jciHitachiAWSAPI === undefined || this.jciHitachiAWSAPI.isLoginFailed == true){
+      if (this.jciHitachiAWSAPI === undefined || this.jciHitachiAWSAPI.isLoginFailed) {
+        if (this.jciHitachiAWSAPI) {
+          await this.jciHitachiAWSAPI.Logout();
+        }
 
         this.log.info('Creating New JciHitachiAWSAPI.');
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,8 +4,8 @@ export const PLUGIN_NAME = 'homebridge-JciHitachi-platform';
 // The platform the plugin creates (see config.json).
 export const PLATFORM_NAME = 'JciHitachi Platform';
 
-// 360 sec = 6 min
-export const LOGIN_RETRY_DELAY = 360 * 1000;
+// 60 sec = 1 min
+export const LOGIN_RETRY_DELAY = 60 * 1000;
 
 export const MAX_NO_OF_FAILED_LOGIN_ATTEMPTS = 5;
 


### PR DESCRIPTION
## Summary
- ensure MQTT client logout handles race conditions and avoids undefined `stop` errors
- centralize login failure handling and retry login instead of skipping device discovery

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a65c7ae170832da4264109fc4724fb